### PR TITLE
chore: add agrawroh to Envoy maintainers list

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -153,6 +153,7 @@ Graduated,Envoy,Matt Klein,bitdrift,mattklein123,https://github.com/envoyproxy/e
 ,,Stephan Zuercher,Turbine Labs,zuercher,
 ,,Greg Greenway,Apple,ggreenway,
 ,,Yan Avlasov,Google,yanavlasov,
+,,Rohit Agrawal,Databricks,agrawroh,
 ,,Ryan Northey,CNCF,phlax,
 ,,Ryan Hamilton,Google,RyanTheOptimist,
 ,,Joshua Marantz,Google,jmarantz,
@@ -2014,3 +2015,4 @@ Sandbox,Stacker,Ramkumar Chinchani,Cisco Systems,rchincha,https://github.com/pro
 ,,Serge Hallyn,Cisco Systems,hallyn,
 ,,Petu Constantin Eusebiu,Cisco Systems,peusebiu,
 ,,Tycho Andersen,Netflix,tych0,
+


### PR DESCRIPTION
### Pre-submission checklist for maintainer updates (delete this if you're updating a different file)

This PR adds `agrawroh` as an Envoy maintainer to this list. Please see the affiliations [here](https://github.com/envoyproxy/envoy/blob/main/OWNERS.md#maintainers).

_If you're adding a new maintainer to the CSV file, please review each of these actions as well:_

- [X] The maintainer has also created or updated their [LFX Individual Dashboard profile](https://openprofile.dev/).
- [X] You've also sent an email with the addresses to <cncf-maintainer-changes@cncf.io> for access to Service Desk and mailing lists.
- [X] Optional: You've also sent a PR with affiliation updates to [cncf/gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#cncf-gitdm).
